### PR TITLE
Accept a DOM element as `container` option

### DIFF
--- a/src/minimasonry.js
+++ b/src/minimasonry.js
@@ -33,7 +33,7 @@ MiniMasonry.prototype.init = function(conf) {
         this.conf.gutterX = this.conf.gutterY = this.conf.gutter;
     }
 
-    this._container = document.querySelector(this.conf.container);
+    this._container = typeof this.conf.container == 'object' && this.conf.container.nodeName ? this.conf.container : document.querySelector(this.conf.container);
     if (!this._container) {
         throw new Error('Container not found or missing');
     }


### PR DESCRIPTION
I want to be able to provide the DOM element of the container directly instead of through a selector.
In my use-case there is no unique selector for the container.