### PR TITLE
Fix resize listener not being removed properly on destroy

### DIFF
--- a/src/minimasonry.js
+++ b/src/minimasonry.js
@@ -53,6 +53,10 @@ MiniMasonry.prototype.init = function(conf) {
     window.addEventListener("resize", onResize);
     this._removeListener = function() {
         window.removeEventListener("resize", onResize);
+        if (this._resizeTimeout != null) {
+            window.clearTimeout(this._resizeTimeout);
+            this._resizeTimeout = null;
+        }
     }
 
     this.layout();


### PR DESCRIPTION
When destroy is called immediately after a window resize, then the throttled re-layout handler is not cancelled.